### PR TITLE
SCP child limit

### DIFF
--- a/src/STBParameters.jl
+++ b/src/STBParameters.jl
@@ -647,7 +647,7 @@ end
     abolished = false
     amounts = [RT(10.0),RT(0)]
     maximum_ages = [5,99]
-    child_limit :: Int = 99
+    max_num_children = 99
     qualifying_benefits = [
         CHILD_TAX_CREDIT,
         UNIVERSAL_CREDIT,

--- a/src/STBParameters.jl
+++ b/src/STBParameters.jl
@@ -647,6 +647,7 @@ end
     abolished = false
     amounts = [RT(10.0),RT(0)]
     maximum_ages = [5,99]
+    child_limit :: Int = 99
     qualifying_benefits = [
         CHILD_TAX_CREDIT,
         UNIVERSAL_CREDIT,

--- a/src/ScottishBenefits.jl
+++ b/src/ScottishBenefits.jl
@@ -40,7 +40,7 @@ function calc_scottish_child_payment!(
     # nkids = count( bu, le_age, scpsys.maximum_age )   
     if( length(bu.children) > 0 ) && has_any( bur, scpsys.qualifying_benefits... )
         scp = 0.0
-        for p in bu.children
+        for p in bu.children[1:min(scpsys.child_limit, length(bu.children))]
             ch = bu.people[p]
             scp += do_stepped_tax_calculation(;
             taxable=ch.age,

--- a/src/ScottishBenefits.jl
+++ b/src/ScottishBenefits.jl
@@ -37,10 +37,11 @@ function calc_scottish_child_payment!(
     scp = 0.0
     bu = benefit_unit
     bur = benefit_unit_result # shortcuts 
-    # nkids = count( bu, le_age, scpsys.maximum_age )   
-    if( length(bu.children) > 0 ) && has_any( bur, scpsys.qualifying_benefits... )
+    # apply a SCP-only child number limit
+    num_applicable_children = min(scpsys.child_limit, length(bu.children))
+    if( num_applicable_children > 0 ) && has_any( bur, scpsys.qualifying_benefits... )
         scp = 0.0
-        for p in bu.children[1:min(scpsys.child_limit, length(bu.children))]
+        for p in bu.children[1:num_applicable_children]
             ch = bu.people[p]
             scp += do_stepped_tax_calculation(;
             taxable=ch.age,

--- a/src/ScottishBenefits.jl
+++ b/src/ScottishBenefits.jl
@@ -38,7 +38,7 @@ function calc_scottish_child_payment!(
     bu = benefit_unit
     bur = benefit_unit_result # shortcuts 
     # apply a SCP-only child number limit
-    num_applicable_children = min(scpsys.child_limit, length(bu.children))
+    num_applicable_children = min(scpsys.max_num_children, length(bu.children))
     if( num_applicable_children > 0 ) && has_any( bur, scpsys.qualifying_benefits... )
         scp = 0.0
         for p in bu.children[1:num_applicable_children]

--- a/test/scottish_benefits_tests.jl
+++ b/test/scottish_benefits_tests.jl
@@ -72,10 +72,25 @@ settings = Settings()
                     bures,
                     bu,
                     bint,
-                    sys.scottish_child_payment 
+                    sys.scottish_child_payment
                 )
                 aggregate!( bures )
                 @test bures.income[SCOTTISH_CHILD_PAYMENT] == 10
+                # child limit: all age-qualifying but capped at 1
+                if ncs >= 2
+                    ages = fill( 3, ncs )
+                    set_childrens_ages!( hh, ages... )
+                    limited_scp = deepcopy( sys.scottish_child_payment )
+                    limited_scp.child_limit = 1
+                    calc_scottish_child_payment!(
+                        bures,
+                        bu,
+                        bint,
+                        limited_scp
+                    )
+                    aggregate!( bures )
+                    @test bures.income[SCOTTISH_CHILD_PAYMENT] == 10
+                end
             end # with children
         end
     end

--- a/test/scottish_benefits_tests.jl
+++ b/test/scottish_benefits_tests.jl
@@ -81,7 +81,7 @@ settings = Settings()
                     ages = fill( 3, ncs )
                     set_childrens_ages!( hh, ages... )
                     limited_scp = deepcopy( sys.scottish_child_payment )
-                    limited_scp.child_limit = 1
+                    limited_scp.max_num_children = 1
                     calc_scottish_child_payment!(
                         bures,
                         bu,


### PR DESCRIPTION
Slightly changes the SCP system to allow a child limit. The limit controls how many times the bu loop over children runs. 